### PR TITLE
Update to use latest node and PureScript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM node:4
+FROM node:9
 
 MAINTAINER Risto Stevcev
+ENV PURESCRIPT_DOWNLOAD_SHA1 f01eb69aa71f5f97c6980f8c68d107480c68ee64
 
-ENV PURESCRIPT_DOWNLOAD_SHA1 3eb742521db7d87359346143a47230b73110ccbe
-
-RUN npm install -g bower pulp@11.0.0
+RUN yarn global add bower pulp@11.0.0
 
 RUN cd /opt \
-    && wget https://github.com/purescript/purescript/releases/download/v0.11.6/linux64.tar.gz \
+    && wget https://github.com/purescript/purescript/releases/download/v0.11.7/linux64.tar.gz \
     && echo "$PURESCRIPT_DOWNLOAD_SHA1 linux64.tar.gz" | sha1sum -c - \
     && tar -xvf linux64.tar.gz \
     && rm /opt/linux64.tar.gz


### PR DESCRIPTION
This updates the Dockerfile to the latest available node container and uses `yarn` to install instead of `npm`, for faster installation. This also updates the version of PureScript to the latest version, `0.11.7`.